### PR TITLE
Fix deprecation error of without an explicit config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,10 @@ submodules:
 conda:
   environment: geovista/requirements/locks/rtd.yml
 
+sphinx:
+  configuration: geovista/docs/src/conf.py
+  fail_on_warning: false
+
 python:
   install:
     - method: pip


### PR DESCRIPTION
See [Deprecation of projects using Sphinx or MkDocs without an explicit configuration file](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config)