### PR TITLE
fix: add plot_docstring=0 to prevent segfault in update workflow

### DIFF
--- a/locale/update.sh
+++ b/locale/update.sh
@@ -11,7 +11,7 @@ set -ex
 # pull po files from transifex
 cd `dirname $0`
 #rm -R pot  # skip this line cause "already unused pot files will not removed" but we must keep these files to avoid commit for only "POT-Creation-Time" line updated. see: https://github.com/sphinx-doc/sphinx/issues/3443
-sphinx-build -T -D plot_gallery=0 -b gettext ../geovista/docs/src pot
+sphinx-build -T -D plot_gallery=0 -D plot_docstring=0 -D plot_inline=0 -b gettext ../geovista/docs/src pot
 sphinx-intl update-txconfig-resources -p pot -d .
 cat .tx/config
 tx push -s --skip


### PR DESCRIPTION
## Description

This PR fixes the segmentation fault (exit code 139) in the `geovista-auto-update` workflow's **update** step.

### Problem
The `sphinx-build` command was failing with a segfault when running on headless runners without EGL/OSMesa:
```
WARN| Failed to load EGL! Please install the EGL library from your distribution's package manager.
WARN| libOSMesa not found. It appears that OSMesa is not installed in your system.
Segmentation fault (core dumped)
```

### Root Cause
Even though `sphinx-build` was invoked with `-D plot_gallery=0`, the GeoVista Sphinx extension still had `plot_docstring=True` active, which caused VTK rendering during source reading.

### Solution
Added `-D plot_docstring=0` to the sphinx-build command in `locale/update.sh`. This is simpler and more robust than installing EGL/OSMesa since the gettext builder doesn't need rendered images anyway.

Fixes #119