### PR TITLE
ci: install Mesa/EGL system libraries for headless rendering

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           host: github.com
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libosmesa6-dev libgl1-mesa-glx
       - name: install
         run: |
           (cd geovista; git fetch origin; git checkout main; git reset --hard origin/main; git branch -a)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libosmesa6-dev libgl1-mesa-glx
+          sudo apt-get install -y libosmesa6-dev libgl1
       - name: install
         run: |
           (cd geovista; git fetch origin; git checkout main; git reset --hard origin/main; git branch -a)


### PR DESCRIPTION
sphinx-build imports geovista which initializes VTK rendering. Without EGL or OSMesa libraries, it causes a segmentation fault in a headless CI environment. Installing `libosmesa6-dev` and setting `PYVISTA_OFF_SCREEN=true` resolves this.